### PR TITLE
Fix typo for appName

### DIFF
--- a/lib/input.dart
+++ b/lib/input.dart
@@ -161,19 +161,20 @@ class WhiteLabelData {
   final String? appUrl;
   final bool? useLogoLoader;
 
-  WhiteLabelData(
-      {this.appName,
-      this.logoLight,
-      this.logoDark,
-      this.defaultLanguage = Language.en,
-      this.mode = ThemeModes.auto,
-      this.theme,
-      this.appUrl,
-      this.useLogoLoader});
+  WhiteLabelData({
+    this.appName,
+    this.logoLight,
+    this.logoDark,
+    this.defaultLanguage = Language.en,
+    this.mode = ThemeModes.auto,
+    this.theme,
+    this.appUrl,
+    this.useLogoLoader,
+  });
 
   Map<String, dynamic> toJson() {
     return {
-      'name': appName,
+      'appName': appName,
       'logoLight': logoLight,
       'logoDark': logoDark,
       'defaultLanguage': defaultLanguage.toString().split('.').last,


### PR DESCRIPTION
The json String passed to Method channel currently has a wrong key for appName. Currently we are passing it as `name` which always results in having a default name on the user flow screen. 

Related Issue on Community Forum: https://web3auth.io/community/t/appname-not-change-when-using-android/6669

Currently same issue can also be observed in Flutter PnP samples

According to [Swift SDK](https://github.com/Web3Auth/web3auth-swift-sdk/blob/4c00016bed255f91808547eb43241519440686ed/Sources/Web3Auth/Types.swift#L87C9-L87C16), & [Android SDK](https://github.com/Web3Auth/web3auth-android-sdk/blob/62816623254348fa39836514205e2c5637856f83/core/src/main/java/com/web3auth/core/types/WhiteLabelData.kt#L4) it should be appName. 