### PR TITLE
Align useLogoLoader default value with Android and iOS SDK

### DIFF
--- a/lib/input.dart
+++ b/lib/input.dart
@@ -293,7 +293,7 @@ class WhiteLabelData {
     this.mode = ThemeModes.auto,
     this.theme,
     this.appUrl,
-    this.useLogoLoader,
+    this.useLogoLoader = false,
   });
 
   Map<String, dynamic> toJson() {
@@ -470,7 +470,7 @@ class Web3AuthOptions {
     this.chainNamespace = ChainNamespace.eip155,
     this.sessionTime = 86400,
     this.mfaSettings,
-    this.originData
+    this.originData,
   })  : chainConfig = null,
         sdkUrl = sdkUrl ?? getSdkUrl(buildEnv ?? BuildEnv.production),
         walletSdkUrl =


### PR DESCRIPTION
Since, the default value of `useLogoLoader` in Android and iOS SDK is false. If I pass just the WhitebaleData object, it disables the useLogoLoader, but that's not the case with Flutter. 